### PR TITLE
Add language middleware to set i18n context

### DIFF
--- a/lang_middleware.go
+++ b/lang_middleware.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/fiatjaf/njump/i18n"
+)
+
+func languageMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		lang := r.URL.Query().Get("lang")
+		if lang == "" {
+			al := r.Header.Get("Accept-Language")
+			if al != "" {
+				p := strings.Split(al, ",")[0]
+				p = strings.SplitN(p, ";", 2)[0]
+				lang = strings.TrimSpace(p)
+			}
+		}
+		if lang == "" {
+			lang = "en"
+		}
+		ctx := i18n.WithLanguage(r.Context(), lang)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -165,10 +165,12 @@ func main() {
 	var mainHandler http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		ipBlock(
 			agentBlock(
-				loggingMiddleware(
-					queueMiddleware(
-						corsM(
-							relay.ServeHTTP,
+				languageMiddleware(
+					loggingMiddleware(
+						queueMiddleware(
+							corsM(
+								relay.ServeHTTP,
+							),
 						),
 					),
 				),


### PR DESCRIPTION
## Summary
- add middleware that gets language code from query param or HTTP header and stores it in request context
- wrap handlers with this language middleware

## Testing
- `go vet ./...` *(fails: undefined types)*
- `go test ./...` *(fails: undefined types)*

------
https://chatgpt.com/codex/tasks/task_e_6842f490cb88832db57cad0bbc426363