### PR TITLE
Propagate language to templates

### DIFF
--- a/about.templ
+++ b/about.templ
@@ -5,9 +5,9 @@ type AboutParams struct {
 }
 
 templ aboutTemplate(params AboutParams) {
-	<!DOCTYPE html>
-	<html class="theme--default font-light">
-		<meta charset="UTF-8"/>
+        <!DOCTYPE html>
+        <html class="theme--default font-light" lang={ params.HeadParams.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			<title>njump - the nostr static gateway</title>
 			<meta name="description" content=""/>

--- a/embedded_profile.templ
+++ b/embedded_profile.templ
@@ -1,9 +1,9 @@
 package main
 
 templ embeddedProfileTemplate(params ProfilePageParams) {
-	<!DOCTYPE html>
-	<html class="theme--default font-light print:text-base">
-		<meta charset="UTF-8"/>
+        <!DOCTYPE html>
+        <html class="theme--default font-light print:text-base" lang={ params.HeadParams.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<link

--- a/error.templ
+++ b/error.templ
@@ -36,9 +36,9 @@ func (e *ErrorPageParams) MessageHTML() template.HTML {
 }
 
 templ errorTemplate(params ErrorPageParams) {
-	<!DOCTYPE html>
-	<html class="theme--default font-light print:text-base">
-		<meta charset="UTF-8"/>
+        <!DOCTYPE html>
+        <html class="theme--default font-light print:text-base" lang={ params.HeadParams.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			<title>Error</title>
 			@headCommonTemplate(params.HeadParams)

--- a/event_page.templ
+++ b/event_page.templ
@@ -13,8 +13,8 @@ templ eventPageTemplate(
 	details DetailsParams,
 	event EnhancedEvent,
 ) {
-	<html class="theme--default font-light print:text-base">
-		<meta charset="UTF-8"/>
+        <html class="theme--default font-light print:text-base" lang={ head.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			<title>{ title }</title>
 			@openGraphTemplate(og)

--- a/homepage.templ
+++ b/homepage.templ
@@ -8,9 +8,9 @@ type HomePageParams struct {
 }
 
 templ homepageTemplate(params HomePageParams) {
-	<!DOCTYPE html>
-	<html class="theme--default font-light">
-		<meta charset="UTF-8"/>
+        <!DOCTYPE html>
+        <html class="theme--default font-light" lang={ params.HeadParams.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			<title>njump - Jump on Board on Nostr, Start Now!</title>
 			<meta name="description" content=""/>

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -39,6 +39,13 @@ func WithLanguage(ctx context.Context, lang string) context.Context {
 	return context.WithValue(ctx, languageKey{}, lang)
 }
 
+// LanguageFromContext extracts the stored language from ctx.
+// If no language was set it returns an empty string.
+func LanguageFromContext(ctx context.Context) string {
+	lang, _ := ctx.Value(languageKey{}).(string)
+	return lang
+}
+
 // Translate returns the localized string for id using the language stored in ctx.
 // If translation is missing, it falls back to English and finally to the id itself.
 func Translate(ctx context.Context, id string, data map[string]any) string {

--- a/other.templ
+++ b/other.templ
@@ -12,9 +12,9 @@ type OtherPageParams struct {
 }
 
 templ otherTemplate(params OtherPageParams) {
-	<!DOCTYPE html>
-	<html class="theme--default font-light print:text-base">
-		<meta charset="UTF-8"/>
+        <!DOCTYPE html>
+        <html class="theme--default font-light print:text-base" lang={ params.HeadParams.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			<title>Nostr Event { strconv.Itoa(params.Kind) } - { params.KindDescription }</title>
 			@headCommonTemplate(params.HeadParams)

--- a/pages.go
+++ b/pages.go
@@ -63,6 +63,7 @@ type HeadParams struct {
 	IsHome      bool
 	IsAbout     bool
 	IsProfile   bool
+	Lang        string
 	NaddrNaked  string
 	NeventNaked string
 	Oembed      string

--- a/profile.templ
+++ b/profile.templ
@@ -26,9 +26,9 @@ type ProfilePageParams struct {
 }
 
 templ profileTemplate(params ProfilePageParams) {
-	<!DOCTYPE html>
-	<html class="theme--default font-light print:text-base">
-		<meta charset="UTF-8"/>
+        <!DOCTYPE html>
+        <html class="theme--default font-light print:text-base" lang={ params.HeadParams.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			if params.Metadata.Name != "" && params.Metadata.DisplayName != "" {
 				<title>

--- a/relay.templ
+++ b/relay.templ
@@ -14,9 +14,9 @@ type RelayPageParams struct {
 }
 
 templ relayTemplate(params RelayPageParams) {
-	<!DOCTYPE html>
-	<html class="theme--default font-light print:text-base">
-		<meta charset="UTF-8"/>
+        <!DOCTYPE html>
+        <html class="theme--default font-light print:text-base" lang={ params.HeadParams.Lang }>
+                <meta charset="UTF-8"/>
 		<head>
 			<title>Nostr Relay { params.Hostname } - { params.Info.Name }</title>
 			<meta property="og:title" content={ params.Hostname + " - Nostr Relay" }/>

--- a/render_about.go
+++ b/render_about.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"net/http"
+
+	"github.com/fiatjaf/njump/i18n"
 )
 
 func renderAbout(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "max-age=3600")
 	err := aboutTemplate(AboutParams{
-		HeadParams: HeadParams{IsAbout: true, IsProfile: false},
+		HeadParams: HeadParams{
+			IsAbout:   true,
+			IsProfile: false,
+			Lang:      i18n.LanguageFromContext(r.Context()),
+		},
 	}).Render(r.Context(), w)
 	if err != nil {
 		log.Warn().Err(err).Msg("error rendering tmpl")

--- a/render_event.go
+++ b/render_event.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/a-h/templ"
+	"github.com/fiatjaf/njump/i18n"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip05"
 	"github.com/nbd-wtf/go-nostr/nip19"
@@ -379,6 +380,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				Oembed:      oembed,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 			Clients:          generateClientList(data.event.Kind, data.nevent),
 			Details:          detailsData,
@@ -409,6 +411,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				Oembed:      oembed,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 			Clients:          generateClientList(data.event.Kind, data.naddr),
 			Details:          detailsData,
@@ -428,6 +431,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				IsProfile:   false,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 
 			Details: detailsData,
@@ -450,6 +454,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				IsProfile:   false,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 
 			Details:   detailsData,
@@ -474,6 +479,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				IsProfile:   false,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 
 			Details:          detailsData,
@@ -528,6 +534,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				IsProfile:   false,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 			TimeZone:      getUTCOffset(location),
 			StartAtDate:   startAtDate,
@@ -557,6 +564,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				IsProfile:   false,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 			PublishedAt: data.Kind30818Metadata.PublishedAt.Format("02 Jan 2006"),
 			WikiEvent:   data.Kind30818Metadata,
@@ -597,6 +605,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				IsProfile:   false,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 			Content:        template.HTML(data.content),
 			HighlightEvent: data.Kind9802Metadata,
@@ -615,6 +624,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 				IsProfile:   false,
 				NaddrNaked:  data.naddrNaked,
 				NeventNaked: data.neventNaked,
+				Lang:        i18n.LanguageFromContext(ctx),
 			},
 
 			Details:         detailsData,

--- a/render_homepage.go
+++ b/render_homepage.go
@@ -2,12 +2,18 @@ package main
 
 import (
 	"net/http"
+
+	"github.com/fiatjaf/njump/i18n"
 )
 
 func renderHomepage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "max-age=3600")
 	err := homepageTemplate(HomePageParams{
-		HeadParams: HeadParams{IsHome: true, IsProfile: false},
+		HeadParams: HeadParams{
+			IsHome:    true,
+			IsProfile: false,
+			Lang:      i18n.LanguageFromContext(r.Context()),
+		},
 	}).Render(r.Context(), w)
 	if err != nil {
 		log.Warn().Err(err).Msg("error rendering tmpl")

--- a/render_profile.go
+++ b/render_profile.go
@@ -5,6 +5,8 @@ import (
 	"html"
 	"html/template"
 	"net/http"
+
+	"github.com/fiatjaf/njump/i18n"
 	"strings"
 	"time"
 )
@@ -91,7 +93,10 @@ func renderProfile(ctx context.Context, r *http.Request, w http.ResponseWriter, 
 
 		nprofile := profile.Nprofile(ctx, sys, 2)
 		params := ProfilePageParams{
-			HeadParams: HeadParams{IsProfile: true},
+			HeadParams: HeadParams{
+				IsProfile: true,
+				Lang:      i18n.LanguageFromContext(ctx),
+			},
 			Details: DetailsParams{
 				HideDetails:     true,
 				CreatedAt:       createdAt,

--- a/render_relay.go
+++ b/render_relay.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fiatjaf/njump/i18n"
 	"github.com/nbd-wtf/go-nostr/nip11"
 )
 
@@ -91,7 +92,10 @@ func renderRelayPage(w http.ResponseWriter, r *http.Request) {
 
 	} else {
 		relayTemplate(RelayPageParams{
-			HeadParams: HeadParams{IsProfile: false},
+			HeadParams: HeadParams{
+				IsProfile: false,
+				Lang:      i18n.LanguageFromContext(r.Context()),
+			},
 			Info:       info,
 			Hostname:   hostname,
 			Proxy:      "https://" + hostname + "/njump/proxy?src=",


### PR DESCRIPTION
## Summary
- add a Lang field to `HeadParams`
- expose `LanguageFromContext` helper
- send language from request context when rendering templates
- pass language through templ parameters so HTML markup knows the language

## Testing
- `go vet ./...` *(fails: undefined: Kind1063Metadata)*
- `go test ./...` *(fails: undefined: Kind1063Metadata)*

------
https://chatgpt.com/codex/tasks/task_e_6842f70967d4832daee9377ab7c17d4f