### PR TITLE
Implement minimal i18n helpers

### DIFF
--- a/about.templ
+++ b/about.templ
@@ -9,7 +9,7 @@ templ aboutTemplate(params AboutParams) {
         <html class="theme--default font-light" lang={ params.HeadParams.Lang }>
                 <meta charset="UTF-8"/>
 		<head>
-			<title>njump - the nostr static gateway</title>
+                        <title>{ t(ctx, "about.title") }</title>
 			<meta name="description" content=""/>
 			@headCommonTemplate(params.HeadParams)
 		</head>

--- a/homepage.templ
+++ b/homepage.templ
@@ -12,7 +12,7 @@ templ homepageTemplate(params HomePageParams) {
         <html class="theme--default font-light" lang={ params.HeadParams.Lang }>
                 <meta charset="UTF-8"/>
 		<head>
-			<title>njump - Jump on Board on Nostr, Start Now!</title>
+                       <title>{ t(ctx, "homepage.title") }</title>
 			<meta name="description" content=""/>
 			@headCommonTemplate(params.HeadParams)
 			<script src="https://cdn.jsdelivr.net/npm/typewriter-effect@2.21.0/dist/core.min.js"></script>

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -2,6 +2,7 @@ package i18n
 
 import (
 	"context"
+	"encoding/json"
 	"io/fs"
 	"path/filepath"
 
@@ -19,6 +20,7 @@ var bundle *i18n.Bundle
 func init() {
 	bundle = i18n.NewBundle(language.English)
 	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
+	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
 	// load translation files from locales directory
 	filepath.WalkDir("locales", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -27,7 +29,7 @@ func init() {
 		if d.IsDir() {
 			return nil
 		}
-		if filepath.Ext(path) == ".toml" {
+		if ext := filepath.Ext(path); ext == ".toml" || ext == ".json" {
 			bundle.LoadMessageFile(path)
 		}
 		return nil

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,10 @@
+{
+  "homepage.title": "TODO",
+  "about.title": "TODO",
+  "top.join": "TODO",
+  "top.why": "TODO",
+  "top.get_started": "TODO",
+  "top.resources": "TODO",
+  "top.development": "TODO",
+  "top.about": "TODO"
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,10 @@
+{
+  "homepage.title": "njump - Jump on Board on Nostr, Start Now!",
+  "about.title": "njump - the nostr static gateway",
+  "top.join": "Join Nostr",
+  "top.why": "Why Nostr?",
+  "top.get_started": "Get started",
+  "top.resources": "Apps & Resources",
+  "top.development": "Join the development",
+  "top.about": "What is Njump?"
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,10 @@
+{
+  "homepage.title": "TODO",
+  "about.title": "TODO",
+  "top.join": "TODO",
+  "top.why": "TODO",
+  "top.get_started": "TODO",
+  "top.resources": "TODO",
+  "top.development": "TODO",
+  "top.about": "TODO"
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,10 @@
+{
+  "homepage.title": "TODO",
+  "about.title": "TODO",
+  "top.join": "TODO",
+  "top.why": "TODO",
+  "top.get_started": "TODO",
+  "top.resources": "TODO",
+  "top.development": "TODO",
+  "top.about": "TODO"
+}

--- a/locales/it.json
+++ b/locales/it.json
@@ -1,0 +1,10 @@
+{
+  "homepage.title": "TODO",
+  "about.title": "TODO",
+  "top.join": "TODO",
+  "top.why": "TODO",
+  "top.get_started": "TODO",
+  "top.resources": "TODO",
+  "top.development": "TODO",
+  "top.about": "TODO"
+}

--- a/templ_helpers.go
+++ b/templ_helpers.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"context"
+
+	"github.com/fiatjaf/njump/i18n"
+)
+
+func t(ctx context.Context, id string) string {
+	return i18n.Translate(ctx, id, nil)
+}

--- a/top.templ
+++ b/top.templ
@@ -6,7 +6,7 @@ templ topTemplate(params HeadParams) {
 		<!-- Mobile header -->
 		<div class="fixed top-0 left-0 right-0 flex justify-between items-center w-full sm:hidden z-40 p-4 bg-white dark:bg-neutral-900">
 			<!-- Join Nostr Button (Mobile - Left) -->
-			<a href="https://nstart.me" class="px-2 py-1 bg-strongpink text-neutral-50 rounded-md text-nowrap">Join Nostr</a>
+                        <a href="https://nstart.me" class="px-2 py-1 bg-strongpink text-neutral-50 rounded-md text-nowrap">{ t(ctx, "top.join") }</a>
 			<!-- Hamburger menu utton -->
 			<button
 				id="mobile-menu-button"
@@ -27,17 +27,17 @@ templ topTemplate(params HeadParams) {
 				<a href="/relays-archive/">Nostr relays archive</a>
 			</div>
 			if !(params.IsHome) {
-				<a href="/" class="mr-4">Why <span class="text-strongpink">Nostr</span>?</a>
+                                <a href="/" class="mr-4">{ t(ctx, "top.why") }</a>
 			}
 			if params.IsHome {
-				<a href="#getstarted" class="mr-4 hover:text-strongpink">Get started</a>
-				<a href="#resources" class="mr-4 hover:text-strongpink">Apps & Resources</a>
-				<a href="#development" class="mr-4 hover:text-strongpink">Join the development</a>
+                                <a href="#getstarted" class="mr-4 hover:text-strongpink">{ t(ctx, "top.get_started") }</a>
+                                <a href="#resources" class="mr-4 hover:text-strongpink">{ t(ctx, "top.resources") }</a>
+                                <a href="#development" class="mr-4 hover:text-strongpink">{ t(ctx, "top.development") }</a>
 			}
 			if !(params.IsAbout) {
-				<a href="/about" class="mr-4">What is <span class="text-strongpink">Njump</span>?</a>
+                                <a href="/about" class="mr-4">{ t(ctx, "top.about") }</a>
 			}
-			<a href="https://nstart.me" class="leading-9 mr-4 px-2 py-1 bg-strongpink text-neutral-50 rounded-md text-nowrap">Join Nostr</a>
+                        <a href="https://nstart.me" class="leading-9 mr-4 px-2 py-1 bg-strongpink text-neutral-50 rounded-md text-nowrap">{ t(ctx, "top.join") }</a>
 		</div>
 		<div class="hidden sm:block sm:w-[14%]">
 			<div
@@ -88,18 +88,18 @@ templ topTemplate(params HeadParams) {
 		<!-- Menu items -->
 		<div class="flex flex-col items-center space-y-8 text-xl text-neutral-800 dark:text-neutral-50 font-semibold">
 			if params.IsHome {
-				<a href="#" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">Why Nostr?</a>
-				<a href="#getstarted" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">Get started</a>
-				<a href="#resources" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">Apps & Resources</a>
-				<a href="#development" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">Join the development</a>
+                                <a href="#" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">{ t(ctx, "top.why") }</a>
+                                <a href="#getstarted" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">{ t(ctx, "top.get_started") }</a>
+                                <a href="#resources" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">{ t(ctx, "top.resources") }</a>
+                                <a href="#development" class="text-2xl hover:text-strongpink" _="on click toggle .hidden on #mobile-menu-overlay">{ t(ctx, "top.development") }</a>
 			}
 			if (!(params.IsAbout) && !(params.IsHome)) || params.IsAbout {
-				<a href="/" class="text-2xl hover:text-strongpink">Why Nostr?</a>
+                                <a href="/" class="text-2xl hover:text-strongpink">{ t(ctx, "top.why") }</a>
 			}
 			if !(params.IsAbout) {
-				<a href="/about" class="text-2xl hover:text-strongpink">What is Njump?</a>
+                                <a href="/about" class="text-2xl hover:text-strongpink">{ t(ctx, "top.about") }</a>
 			}
-			<a href="https://nstart.me" class="text-2xl text-strongpink">Join Nostr</a>
+                        <a href="https://nstart.me" class="text-2xl text-strongpink">{ t(ctx, "top.join") }</a>
 		</div>
 		<!-- Theme toggle -->
 		<div class="absolute bottom-16 flex justify-center items-center space-x-3 text-neutral-400 dark:text-neutral-500 font-semibold">


### PR DESCRIPTION
## Summary
- add `t()` helper for templates
- register JSON translation files
- localize titles and navigation labels
- add English strings and placeholder European locales

## Testing
- `go vet ./...` *(fails: undefined Kind1063Metadata)*

------
https://chatgpt.com/codex/tasks/task_e_6842fd563254832d8e60f17fc4c7d7cb