### PR TITLE
Ensure language code safety

### DIFF
--- a/lang_middleware.go
+++ b/lang_middleware.go
@@ -3,10 +3,13 @@ package main
 import (
 	"context"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/fiatjaf/njump/i18n"
 )
+
+var langRegex = regexp.MustCompile("^[a-z]{2}$")
 
 func languageMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -36,6 +39,9 @@ func languageMiddleware(next http.HandlerFunc) http.HandlerFunc {
 		lang = strings.ToLower(raw)
 		if i := strings.Index(lang, "-"); i != -1 {
 			lang = lang[:i]
+		}
+		if !langRegex.MatchString(lang) {
+			lang = s.DefaultLanguage
 		}
 		log.Debug().
 			Str("source", source).


### PR DESCRIPTION
## Summary
- add regex check in `languageMiddleware`
- default to fallback language if regex doesn't match

## Testing
- `go test ./...` *(fails: undefined symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68590d7cd340832da858bd42dfc105d5